### PR TITLE
Give up on 2.1.2 tag/release.  Prepare for a 2.1.3 release

### DIFF
--- a/deprecat/__init__.py
+++ b/deprecat/__init__.py
@@ -6,8 +6,8 @@ deprecat
 
 """
 
-__version__ = "2.1.2"
-__author__ = u"Meenal Jhajharia <meenal@mjhajharia.com> and contributors"
-__credits__ = "(c) Meenal Jhajharia and contributors"
+__version__ = "2.1.3"
+__author__ = u"Meenal Jhajharia <meenal@mjhajharia.com>, Paul Haesler <linkjuggler@gmail.com> and contributors"
+__credits__ = "(c) Meenal Jhajharia, Paul Haesler, and contributors"
 
 from deprecat.classic import deprecat

--- a/setup.py
+++ b/setup.py
@@ -5,9 +5,9 @@ from setuptools import setup
 
 setup(
     name='deprecat',
-    version='2.1.1',
+    version='2.1.3',
     url='https://github.com/mjhajharia/deprecat',
-    download_url='https://github.com/mjhajharia/deprecat/archive/refs/tags/v2.1.1.tar.gz',
+    download_url='https://github.com/mjhajharia/deprecat/archive/refs/tags/v2.1.3.tar.gz',
     license='MIT',
     author='Meenal Jhajharia',  
     author_email='meenal@mjhajharia.com',


### PR DESCRIPTION
Doing a 2.1.2 release to PyPI at this point is getting problematic as it would/could not match the v2.1.2 tag on Github.

This PR prepares for a 2.1.3 release.  After merging this, and doing a v2.1.3 release through github, the upload to pypi should proceed automatically, if not it can be done manually.

In future should be updated to use `scm_version` or something so we can do version number management purely through the github release mechanism.  Nobody wants to have to remember to update version numbers in multiple places.